### PR TITLE
Add Press page with framer-motion integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "buffer": "^6.0.3",
+        "framer-motion": "^12.23.24",
         "gray-matter": "^4.0.3",
         "raw-loader": "^4.0.2",
         "react": "^18.3.1",
@@ -9810,6 +9811,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.24",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
+      "integrity": "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -13915,6 +13943,21 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/mozjpeg": {
       "version": "8.0.0",
@@ -18852,7 +18895,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "buffer": "^6.0.3",
+    "framer-motion": "^12.23.24",
     "gray-matter": "^4.0.3",
     "raw-loader": "^4.0.2",
     "react": "^18.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import Vehicles from "./pages/Vehicles";
 import NotFound from "./pages/NotFound";
 import LabInfo from "./pages/LabInfo";
 import Team2024Page from "./pages/teams/2024";
+import Press from "./pages/Press";
 
 import NavigateExternal from "./components/NavigateExternal";
 
@@ -71,6 +72,10 @@ const router = createBrowserRouter(
       path: "/sponsor_packet",
       element: <NavigateExternal to="https://mil.ufl.edu/sponsorship.pdf" />,
     },
+    {
+      path: "/press",
+      element: <Press />,
+    }
   ],
   {},
 );

--- a/src/pages/Press.js
+++ b/src/pages/Press.js
@@ -1,0 +1,177 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { motion } from "framer-motion";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+
+const PressSection = ({ id, title, pressItems, bgColor, isYearOnly }) => {
+return (
+    <motion.div
+    id={id}
+    initial={{ opacity: 0, y: 30 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    whileHover={{ y: -5 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.6, type: "spring", stiffness: 200 }}
+    className={`py-12 px-8 rounded-3xl shadow-xl ${bgColor} mb-12 border-l-8 border-blue-500`}
+    >
+    <h2 className="text-3xl font-extrabold mb-8 text-blue-700">{title}</h2>
+
+    <ul className={`flex flex-wrap gap-4 ${!isYearOnly ? "flex-col" : ""}`}>
+        {pressItems.map((item, index) => (
+        <motion.li
+            key={index}
+            whileHover={{ scale: 1.03 }}
+            transition={{ type: "spring", stiffness: 300 }}
+            className={`${
+            !isYearOnly
+                ? "bg-white p-5 rounded-xl shadow-md hover:shadow-lg transition-all duration-300 border border-blue-100"
+                : ""
+            }`}
+        >
+            <a
+            href={item.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${
+                isYearOnly
+                ? "px-4 py-2 bg-gradient-to-r from-blue to-blue-500 text-blue-800 font-semibold rounded-full shadow hover:shadow-lg transition-all duration-300"
+                : "text-blue-700 hover:text-blue-900 font-medium hover:underline"
+            }`}
+            >
+            {isYearOnly ? item.title : item.title}
+            </a>
+        </motion.li>
+        ))}
+    </ul>
+    </motion.div>
+);
+};
+
+PressSection.propTypes = {
+id: PropTypes.string.isRequired,
+title: PropTypes.string.isRequired,
+pressItems: PropTypes.arrayOf(
+    PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string,
+    })
+).isRequired,
+bgColor: PropTypes.string,
+isYearOnly: PropTypes.bool,
+};
+
+PressSection.defaultProps = {
+bgColor: "bg-gradient-to-r from-white to-blue-50",
+isYearOnly: false,
+};
+
+const Press = () => {
+const competitionPapers = [
+    { title: "2024", url: "https://subjugator.org/?s=2024" },
+    { title: "2023", url: "https://subjugator.org/?s=2023" },
+    { title: "2022", url: "https://subjugator.org/?s=2022" },
+    { title: "2021", url: "https://subjugator.org/?s=2021" },
+    { title: "2020", url: "https://subjugator.org/?s=2020" },
+    { title: "2019", url: "https://subjugator.org/?s=2024" },
+    { title: "2018", url: "https://subjugator.org/?s=2023" },
+    { title: "2017", url: "https://subjugator.org/?s=2022" },
+    { title: "2016", url: "https://subjugator.org/?s=2021" },
+    { title: "2015", url: "https://subjugator.org/?s=2020" },
+];
+
+const posters = [
+    { title: "AUVSI Poster 2014", url: "#" },
+    { title: "AUVSI Poster 2013", url: "#" },
+];
+
+const publications = [
+    { title: "FCRAR Publication 2011", url: "#" },
+    { title: "FCRAR Publication 2010", url: "#" },
+];
+
+const pressItems = [
+    { title: "SubjuGator Submarine Testing, January 5, 2017", url: "#" },
+    { title: "UF’s ‘SubjuGator’ begins competing, July 14, 2010", url: "#" },
+];
+
+const scrollToSection = (id) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+};
+
+return (
+    <>
+    <Navbar />
+
+    <div className="max-w-6xl mx-auto py-16 px-6 relative">
+        <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+        className="text-5xl font-extrabold mb-6 text-center text-blue-700"
+        >
+        Press & Publications
+        </motion.h1>
+
+
+        <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.5, duration: 0.8 }}
+        className="flex justify-center gap-4 flex-wrap mb-12"
+        >
+        {[
+            { label: "Competition Papers", id: "papers" },
+            { label: "Posters", id: "posters" },
+            { label: "Publications", id: "publications" },
+            { label: "Press Announcements", id: "announcements" },
+        ].map((btn) => (
+            <motion.button
+            key={btn.id}
+            onClick={() => scrollToSection(btn.id)}
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.95 }}
+            className="px-6 py-3 bg-gradient-to-r from-white to-blue-500 text-blue-800 font-semibold rounded-full shadow-lg hover:shadow-xl transition-all duration-300"
+            >
+            {btn.label}
+            </motion.button>
+        ))}
+        </motion.div>
+
+
+        <PressSection
+        id="papers"
+        title="Competition Papers"
+        pressItems={competitionPapers}
+        bgColor="bg-gradient-to-r from-white to-blue-50"
+        isYearOnly={true} 
+        />
+
+        <PressSection
+        id="posters"
+        title="Competition Posters"
+        pressItems={posters}
+        bgColor="bg-gradient-to-r from-white to-blue-100"
+        />
+
+        <PressSection
+        id="publications"
+        title="Conference & Journal Publications"
+        pressItems={publications}
+        bgColor="bg-gradient-to-r from-white to-blue-200"
+        />
+
+        <PressSection
+        id="announcements"
+        title="Press Announcements"
+        pressItems={pressItems}
+        bgColor="bg-gradient-to-r from-white to-blue-300"
+        />
+    </div>
+
+    <Footer />
+    </>
+);
+};
+
+export default Press;


### PR DESCRIPTION
Introduces a new Press page at /press, featuring animated sections for competition papers, posters, publications, and press announcements using framer-motion. Updates routing in src/index.js and adds framer-motion as a dependency in package.json.

<img width="1889" height="974" alt="image" src="https://github.com/user-attachments/assets/833c7c88-0d3a-41bd-a0ca-d99b5030ba76" />
<img width="1782" height="972" alt="image" src="https://github.com/user-attachments/assets/ba9f9ed3-546e-45df-9011-5458d394411a" />
